### PR TITLE
chore: Update loofah from 2.2.0 to 2.2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -725,7 +725,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
the previous Loofah version allows non-whitelisted attributes to be
present in sanitized output when input with specially-crafted HTML
fragments.

- see flavorjones/loofah#144